### PR TITLE
Fix Masternode Reward Name in Wallet

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -54,7 +54,11 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet* 
                     if (IsMine(*wallet, outAddress)) {
                         isminetype mine = wallet->IsMine(wtx.vout[i]);
                         sub.involvesWatchAddress = mine & ISMINE_WATCH_ONLY;
-                        sub.type = TransactionRecord::MNReward;
+						if (i == 2) {
+							sub.type = TransactionRecord::FNReward;
+						} else {
+							sub.type = TransactionRecord::MNReward;
+						}
                         sub.address = CBitcoinAddress(outAddress).ToString();
                         sub.credit = wtx.vout[i].nValue;
                     }
@@ -316,7 +320,7 @@ void TransactionRecord::updateStatus(const CWalletTx& wtx)
         }
     }
     // For generated transactions, determine maturity
-    else if (type == TransactionRecord::Generated || type == TransactionRecord::StakeMint || type == TransactionRecord::MNReward) {
+    else if (type == TransactionRecord::Generated || type == TransactionRecord::StakeMint || type == TransactionRecord::MNReward || type TransactionRecord::FNReward) {
         if (wtx.GetBlocksToMaturity() > 0) {
             status.status = TransactionStatus::Immature;
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -54,11 +54,11 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet* 
                     if (IsMine(*wallet, outAddress)) {
                         isminetype mine = wallet->IsMine(wtx.vout[i]);
                         sub.involvesWatchAddress = mine & ISMINE_WATCH_ONLY;
-						if (i == 2) {
-							sub.type = TransactionRecord::FNReward;
-						} else {
-							sub.type = TransactionRecord::MNReward;
-						}
+                        if (i == 2) {
+                            sub.type = TransactionRecord::FNReward;
+                        } else {
+                            sub.type = TransactionRecord::MNReward;
+                        }
                         sub.address = CBitcoinAddress(outAddress).ToString();
                         sub.credit = wtx.vout[i].nValue;
                     }

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -79,7 +79,7 @@ public:
         SendToOther,
         RecvWithAddress,
         MNReward,
-		FNReward,
+        FNReward,
         RecvFromOther,
         SendToSelf,
         ZerocoinMint,

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -79,6 +79,7 @@ public:
         SendToOther,
         RecvWithAddress,
         MNReward,
+		FNReward,
         RecvFromOther,
         SendToSelf,
         ZerocoinMint,

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -331,6 +331,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord* wtx) const
     case TransactionRecord::RecvWithAddress:
         return tr("Received with");
     case TransactionRecord::MNReward:
+        return tr("Masternode Reward");
+    case TransactionRecord::FNReward:
         return tr("Fundamentalnode Reward");
     case TransactionRecord::RecvFromOther:
         return tr("Received from");
@@ -377,6 +379,7 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord* wtx
     case TransactionRecord::Generated:
     case TransactionRecord::StakeMint:
     case TransactionRecord::MNReward:
+	case TransactionRecord::FNReward:
         return QIcon(":/icons/tx_mined");
     case TransactionRecord::RecvWithObfuscation:
     case TransactionRecord::RecvWithAddress:
@@ -405,6 +408,7 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord* wtx, b
         return QString::fromStdString(wtx->address) + watchAddress;
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::MNReward:
+	case TransactionRecord::FNReward:
     case TransactionRecord::RecvWithObfuscation:
     case TransactionRecord::SendToAddress:
     case TransactionRecord::Generated:
@@ -435,6 +439,7 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord* wtx) const
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::SendToAddress:
     case TransactionRecord::Generated:
+	case TransactionRecord::FNReward:
     case TransactionRecord::MNReward: {
         QString label = walletModel->getAddressTableModel()->labelForAddress(QString::fromStdString(wtx->address));
         if (label.isEmpty())
@@ -510,7 +515,7 @@ QString TransactionTableModel::formatTooltip(const TransactionRecord* rec) const
 {
     QString tooltip = formatTxStatus(rec) + QString("\n") + formatTxType(rec);
     if (rec->type == TransactionRecord::RecvFromOther || rec->type == TransactionRecord::SendToOther ||
-        rec->type == TransactionRecord::SendToAddress || rec->type == TransactionRecord::RecvWithAddress || rec->type == TransactionRecord::MNReward) {
+        rec->type == TransactionRecord::SendToAddress || rec->type == TransactionRecord::RecvWithAddress || rec->type == TransactionRecord::MNReward || rec->type == TransactionRecord::FNReward) {
         tooltip += QString(" ") + formatTxToAddress(rec, true);
     }
     return tooltip;

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -379,7 +379,7 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord* wtx
     case TransactionRecord::Generated:
     case TransactionRecord::StakeMint:
     case TransactionRecord::MNReward:
-	case TransactionRecord::FNReward:
+    case TransactionRecord::FNReward:
         return QIcon(":/icons/tx_mined");
     case TransactionRecord::RecvWithObfuscation:
     case TransactionRecord::RecvWithAddress:

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -99,7 +99,8 @@ TransactionView::TransactionView(QWidget* parent) : QWidget(parent), model(0), t
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
     typeWidget->addItem(tr("Minted"), TransactionFilterProxy::TYPE(TransactionRecord::StakeMint));
-    typeWidget->addItem(tr("Fundamentalnode Reward"), TransactionFilterProxy::TYPE(TransactionRecord::MNReward));
+    typeWidget->addItem(tr("Masternode Reward"), TransactionFilterProxy::TYPE(TransactionRecord::MNReward));
+    typeWidget->addItem(tr("Fundamentalnode Reward"), TransactionFilterProxy::TYPE(TransactionRecord::FNReward));
     typeWidget->addItem(tr("Received Vit from zVit"), TransactionFilterProxy::TYPE(TransactionRecord::RecvFromZerocoinSpend));
     typeWidget->addItem(tr("Zerocoin Mint"), TransactionFilterProxy::TYPE(TransactionRecord::ZerocoinMint));
     typeWidget->addItem(tr("Zerocoin Spend"), TransactionFilterProxy::TYPE(TransactionRecord::ZerocoinSpend));


### PR DESCRIPTION
Masternode Rewards show as Fundamentalnode Reward in the wallet.  This should correct that.