### PR TITLE
Changed money supply

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3329,7 +3329,7 @@ bool RecalculateVITSupply(int nHeightStart)
     CBlockIndex* pindex = chainActive[nHeightStart];
     CAmount nSupplyPrev = pindex->pprev->nMoneySupply;
     if (nHeightStart == Params().Zerocoin_StartHeight())
-        nSupplyPrev = CAmount(5449796547496199);
+        nSupplyPrev = CAmount(649916627717750);
 
     while (true) {
         if (pindex->nHeight % 1000 == 0)


### PR DESCRIPTION
Money supply was incorrect due to a line left over from the PIVX fork, now changed it to the proper value.
It requires a reindex to test this issue.