### PR TITLE
configure: fix build os variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1096,7 +1096,7 @@ echo "  with upnp     = $use_upnp"
 echo "  debug enabled = $enable_debug"
 echo
 echo "  target os     = $TARGET_OS"
-echo "  build os      = $BUILD_OS"
+echo "  build os      = $build_os"
 echo
 echo "  CC            = $CC"
 echo "  CFLAGS        = $CFLAGS"


### PR DESCRIPTION
Hi!
This will fix the build os variable when you run a `./configure`.